### PR TITLE
bugfix example_ADC_sync_plot.py

### DIFF
--- a/example_ADC_sync_plot.py
+++ b/example_ADC_sync_plot.py
@@ -30,12 +30,12 @@ root = tkinter.Tk()
 root.geometry(f"{width}x{height}+0+200")
 
 stupidplot = StupidPlot()
-for x in range(5):
-    ADC_data = rp.adc(
-            channel_mask=sum(2**ch for ch in channels),
-            blocksize=width*len(channels),  # one ADC sample per ?????, per channel
-            clkdiv=48000//kSPS_per_ch)['data']
-    channel_data = [ADC_data[ofs::len(channels)] for ofs,name in enumerate(channels)]
-    stupidplot.plot(channel_data)
+#for x in range(5):
+ADC_data = rp.adc(
+        channel_mask=sum(2**ch for ch in channels),
+        blocksize=width*len(channels),  # one ADC sample per ?????, per channel
+        clkdiv=48000//kSPS_per_ch)['data']
+channel_data = [ADC_data[ofs::len(channels)] for ofs,name in enumerate(channels)]
+stupidplot.plot(channel_data)
 
 root.mainloop()


### PR DESCRIPTION
Hi.
I think line 33 of the file is not necessary:

for x in range(5):

it makes the plot to happen 5 times for all channels instead of 1 time. I've found this bug while trying to visualize a pwm signal:
this is how current code visualizes pwm signal:
![Screenshot from 2023-08-31 22-09-10](https://github.com/FilipDominec/rp2daq/assets/7839141/32a866e9-adfa-4a16-b6e9-d63fc8496341)

and after commenting out 

![Screenshot from 2023-08-31 22-09-43](https://github.com/FilipDominec/rp2daq/assets/7839141/38f1b474-b8cc-423f-bd0a-c519d9852812)
